### PR TITLE
fix: sdk:10.0 Dockerfile + IHistoryRepository guard on Migrate()

### DIFF
--- a/Dockerfile-workflow-service
+++ b/Dockerfile-workflow-service
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 ARG GITVERSION
 WORKDIR /app
 ARG GITVERSION

--- a/ServiceWorkflowPlugin/Core.cs
+++ b/ServiceWorkflowPlugin/Core.cs
@@ -41,6 +41,8 @@ using Infrastructure.Helpers;
 using Installers;
 using Messages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microting.eForm.Dto;
 using Microting.eFormWorkflowBase.Infrastructure.Data;
 using Microting.eFormWorkflowBase.Infrastructure.Data.Factories;
@@ -186,7 +188,11 @@ public class Core : ISdkEventHandler
                 var contextFactory = new WorkflowPnContextFactory();
 
                 _dbContext = contextFactory.CreateDbContext(new[] { connectionString });
-                _dbContext.Database.Migrate();
+                var historyRepo = _dbContext.GetService<IHistoryRepository>();
+                if (!historyRepo.Exists() || _dbContext.Database.GetPendingMigrations().Any())
+                {
+                    _dbContext.Database.Migrate();
+                }
 
                 _dbContextHelper = new DbContextHelper(connectionString);
 


### PR DESCRIPTION
## Summary
- Upgrade build stage from dotnet/sdk:9.0 to 10.0 (project targets net10.0)
- Guard Database.Migrate() with IHistoryRepository.Exists() — no DDL when schema is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)